### PR TITLE
implement Pinned repository list

### DIFF
--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -162,6 +162,11 @@ export interface IAppState {
   /** Map from the emoji shortcut (e.g., :+1:) to the image's local path. */
   readonly emoji: Map<string, string>
 
+  readonly showRootSidebar: boolean
+
+  /** The width of the root sidebar (pinned repostory list) */
+  readonly rootSidebarWith: IConstrainedValue
+
   /**
    * The width of the repository sidebar.
    *
@@ -175,9 +180,6 @@ export interface IAppState {
    * repository.
    */
   readonly sidebarWidth: IConstrainedValue
-
-  /** The width of the root sidebar (pinned repostory list) */
-  readonly rootSidebarWith: IConstrainedValue
 
   /** The width of the commit summary column in the history view */
   readonly commitSummaryWidth: IConstrainedValue

--- a/app/src/lib/app-state.ts
+++ b/app/src/lib/app-state.ts
@@ -176,6 +176,9 @@ export interface IAppState {
    */
   readonly sidebarWidth: IConstrainedValue
 
+  /** The width of the root sidebar (pinned repostory list) */
+  readonly rootSidebarWith: IConstrainedValue
+
   /** The width of the commit summary column in the history view */
   readonly commitSummaryWidth: IConstrainedValue
 

--- a/app/src/lib/menu-update.ts
+++ b/app/src/lib/menu-update.ts
@@ -126,6 +126,7 @@ const allMenuIds: ReadonlyArray<MenuIDs> = [
   'show-history',
   'show-repository-list',
   'show-branches-list',
+  'toggle-pinned-repository-list',
   'open-working-directory',
   'show-repository-settings',
   'open-external-editor',
@@ -239,6 +240,7 @@ function getRepositoryMenuBuilder(state: IAppState): MenuStateBuilder {
     'show-changes',
     'show-history',
     'show-branches-list',
+    'toggle-pinned-repository-list',
     'open-external-editor',
     'compare-to-branch',
   ]

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -458,6 +458,8 @@ export class AppStore extends TypedBaseStore<IAppState> {
    */
   private appIsFocused: boolean = false
 
+  private showRootSideBar: boolean = true
+
   private sidebarWidth = constrain(defaultSidebarWidth)
   private rootSidebarWidth = constrain(defaultRootSidebarWidth)
   private commitSummaryWidth = constrain(defaultCommitSummaryWidth)
@@ -973,8 +975,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
       showWelcomeFlow: this.showWelcomeFlow,
       focusCommitMessage: this.focusCommitMessage,
       emoji: this.emoji,
-      sidebarWidth: this.sidebarWidth,
+      showRootSidebar: this.showRootSideBar,
       rootSidebarWith: this.rootSidebarWidth,
+      sidebarWidth: this.sidebarWidth,
       commitSummaryWidth: this.commitSummaryWidth,
       stashedFilesWidth: this.stashedFilesWidth,
       pullRequestFilesListWidth: this.pullRequestFileListWidth,
@@ -5124,6 +5127,13 @@ export class AppStore extends TypedBaseStore<IAppState> {
   public _setCommitMessageFocus(focus: boolean) {
     if (this.focusCommitMessage !== focus) {
       this.focusCommitMessage = focus
+      this.emitUpdate()
+    }
+  }
+
+  public _setShowRootSidebar(show: boolean) {
+    if (this.showRootSideBar !== show) {
+      this.showRootSideBar = show
       this.emitUpdate()
     }
   }

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -338,7 +338,9 @@ const RecentRepositoriesKey = 'recently-selected-repositories'
 const RecentRepositoriesLength = 3
 
 const defaultSidebarWidth: number = 250
+const defaultRootSidebarWidth: number = 200
 const sidebarWidthConfigKey: string = 'sidebar-width'
+const rootSidebarWidthConfigKey: string = 'root-sidebar-width'
 
 const defaultCommitSummaryWidth: number = 250
 const commitSummaryWidthConfigKey: string = 'commit-summary-width'
@@ -457,6 +459,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
   private appIsFocused: boolean = false
 
   private sidebarWidth = constrain(defaultSidebarWidth)
+  private rootSidebarWidth = constrain(defaultRootSidebarWidth)
   private commitSummaryWidth = constrain(defaultCommitSummaryWidth)
   private stashedFilesWidth = constrain(defaultStashedFilesWidth)
   private pullRequestFileListWidth = constrain(defaultPullRequestFileListWidth)
@@ -971,6 +974,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       focusCommitMessage: this.focusCommitMessage,
       emoji: this.emoji,
       sidebarWidth: this.sidebarWidth,
+      rootSidebarWith: this.rootSidebarWidth,
       commitSummaryWidth: this.commitSummaryWidth,
       stashedFilesWidth: this.stashedFilesWidth,
       pullRequestFilesListWidth: this.pullRequestFileListWidth,
@@ -2083,6 +2087,9 @@ export class AppStore extends TypedBaseStore<IAppState> {
     this.sidebarWidth = constrain(
       getNumber(sidebarWidthConfigKey, defaultSidebarWidth)
     )
+    this.rootSidebarWidth = constrain(
+      getNumber(rootSidebarWidthConfigKey, defaultRootSidebarWidth)
+    )
     this.commitSummaryWidth = constrain(
       getNumber(commitSummaryWidthConfigKey, defaultCommitSummaryWidth)
     )
@@ -2231,8 +2238,22 @@ export class AppStore extends TypedBaseStore<IAppState> {
     // 220 was determined as the minimum value since it is the smallest width
     // that will still fit the placeholder text in the branch selector textbox
     // of the history tab
-    const maxSidebarWidth = available - toolbarButtonsWidth
-    this.sidebarWidth = constrain(this.sidebarWidth, 220, maxSidebarWidth)
+    const minSiderBarWidth = 220
+    const maxRootSidebarWidth =
+      available - toolbarButtonsWidth - minSiderBarWidth
+    this.rootSidebarWidth = constrain(
+      this.rootSidebarWidth,
+      160,
+      maxRootSidebarWidth
+    )
+
+    const maxSidebarWidth =
+      available - toolbarButtonsWidth - this.rootSidebarWidth.value
+    this.sidebarWidth = constrain(
+      this.sidebarWidth,
+      minSiderBarWidth,
+      maxSidebarWidth
+    )
 
     // Now calculate the width we have left to distribute for the other panes
     available -= clamp(this.sidebarWidth)
@@ -5116,9 +5137,30 @@ export class AppStore extends TypedBaseStore<IAppState> {
     return Promise.resolve()
   }
 
+  public _setRootSidebarWidth(width: number): Promise<void> {
+    this.rootSidebarWidth = { ...this.rootSidebarWidth, value: width }
+    setNumber(rootSidebarWidthConfigKey, width)
+    this.updateResizableConstraints()
+    this.emitUpdate()
+
+    return Promise.resolve()
+  }
+
   public _resetSidebarWidth(): Promise<void> {
     this.sidebarWidth = { ...this.sidebarWidth, value: defaultSidebarWidth }
     localStorage.removeItem(sidebarWidthConfigKey)
+    this.updateResizableConstraints()
+    this.emitUpdate()
+
+    return Promise.resolve()
+  }
+
+  public _resetRootSidebarWidth(): Promise<void> {
+    this.rootSidebarWidth = {
+      ...this.rootSidebarWidth,
+      value: defaultRootSidebarWidth,
+    }
+    localStorage.removeItem(rootSidebarWidthConfigKey)
     this.updateResizableConstraints()
     this.emitUpdate()
 

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -195,6 +195,15 @@ export function buildDefaultMenu({
       },
       separator,
       {
+        label: __DARWIN__
+          ? 'Toggle Pinned Repository List'
+          : 'Toggle &Pinned Repository List',
+        id: 'toggle-pinned-repository-list',
+        accelerator: 'Ctrl+R',
+        click: emit('toggle-pinned-repository-list'),
+      },
+      separator,
+      {
         label: __DARWIN__ ? 'Go to Summary' : 'Go to &Summary',
         id: 'go-to-commit-message',
         accelerator: 'CmdOrCtrl+G',

--- a/app/src/main-process/menu/build-default-menu.ts
+++ b/app/src/main-process/menu/build-default-menu.ts
@@ -199,7 +199,7 @@ export function buildDefaultMenu({
           ? 'Toggle Pinned Repository List'
           : 'Toggle &Pinned Repository List',
         id: 'toggle-pinned-repository-list',
-        accelerator: 'Ctrl+R',
+        accelerator: 'CmdOrCtrl+Alt+L',
         click: emit('toggle-pinned-repository-list'),
       },
       separator,

--- a/app/src/main-process/menu/menu-event.ts
+++ b/app/src/main-process/menu/menu-event.ts
@@ -38,6 +38,7 @@ export type MenuEvent =
   | 'show-release-notes-popup'
   | 'show-stashed-changes'
   | 'hide-stashed-changes'
+  | 'toggle-pinned-repository-list'
   | 'test-show-notification'
   | 'test-prune-branches'
   | 'find-text'

--- a/app/src/models/menu-ids.ts
+++ b/app/src/models/menu-ids.ts
@@ -23,6 +23,7 @@ export type MenuIDs =
   | 'show-history'
   | 'show-repository-list'
   | 'show-branches-list'
+  | 'toggle-pinned-repository-list'
   | 'open-working-directory'
   | 'show-repository-settings'
   | 'open-external-editor'

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -172,6 +172,7 @@ import { UnsupportedOSBannerDismissedAtKey } from './banners/windows-version-no-
 import { offsetFromNow } from '../lib/offset-from'
 import { getNumber } from '../lib/local-storage'
 import { RepoRulesBypassConfirmation } from './repository-rules/repo-rules-bypass-confirmation'
+import { Resizable } from './resizable'
 
 const MinuteInMilliseconds = 1000 * 60
 const HourInMilliseconds = MinuteInMilliseconds * 60
@@ -2751,17 +2752,39 @@ export class App extends React.Component<IAppProps, IAppState> {
     })
   }
 
+  private handleRootSidebarWidthReset = () => {
+    this.props.dispatcher.resetRootSidebarWidth()
+  }
+
+  private handleRootSidebarResize = (width: number) => {
+    this.props.dispatcher.setRootSidebarWidth(width)
+  }
+
   private renderApp() {
     return (
       <div
         id="desktop-app-contents"
         className={this.getDesktopAppContentsClassNames()}
       >
-        {this.renderToolbar()}
-        {this.renderBanner()}
-        {this.renderRepository()}
-        {this.renderPopups()}
-        {this.renderDragElement()}
+        <div id="app-root-column-layout">
+          <Resizable
+            id="app-root-column-layout-sidebar"
+            width={this.state.rootSidebarWith.value + 1} // +1px for the border
+            maximumWidth={this.state.rootSidebarWith.max}
+            minimumWidth={this.state.rootSidebarWith.min}
+            onReset={this.handleRootSidebarWidthReset}
+            onResize={this.handleRootSidebarResize}
+          >
+            {this.renderRepositoryList()}
+          </Resizable>
+          <div style={{ flex: 1 }}>
+            {this.renderToolbar()}
+            {this.renderBanner()}
+            {this.renderRepository()}
+            {this.renderPopups()}
+            {this.renderDragElement()}
+          </div>
+        </div>
       </div>
     )
   }
@@ -2919,7 +2942,6 @@ export class App extends React.Component<IAppProps, IAppState> {
      * in some of our dialogs (noticed with Lists). Disabled this when dialogs
      * are open */
     const enableFocusTrap = this.state.currentPopup === null
-
     return (
       <ToolbarDropdown
         icon={icon}

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -466,6 +466,8 @@ export class App extends React.Component<IAppProps, IAppState> {
         return this.showStashedChanges()
       case 'hide-stashed-changes':
         return this.hideStashedChanges()
+      case 'toggle-pinned-repository-list':
+        return this.togglePinnedRepositoryList()
       case 'test-show-notification':
         return this.testShowNotification()
       case 'test-prune-branches':
@@ -1092,6 +1094,10 @@ export class App extends React.Component<IAppProps, IAppState> {
     }
 
     this.props.dispatcher.hideStashedChanges(state.repository)
+  }
+
+  private togglePinnedRepositoryList() {
+    this.props.dispatcher.setShowRootSidebar(!this.state.showRootSidebar)
   }
 
   public componentDidMount() {
@@ -2767,16 +2773,18 @@ export class App extends React.Component<IAppProps, IAppState> {
         className={this.getDesktopAppContentsClassNames()}
       >
         <div id="app-root-column-layout">
-          <Resizable
-            id="app-root-column-layout-sidebar"
-            width={this.state.rootSidebarWith.value + 1} // +1px for the border
-            maximumWidth={this.state.rootSidebarWith.max}
-            minimumWidth={this.state.rootSidebarWith.min}
-            onReset={this.handleRootSidebarWidthReset}
-            onResize={this.handleRootSidebarResize}
-          >
-            {this.renderRepositoryList()}
-          </Resizable>
+          {this.state.showRootSidebar ? (
+            <Resizable
+              id="app-root-column-layout-sidebar"
+              width={this.state.rootSidebarWith.value + 1} // +1px for the border
+              maximumWidth={this.state.rootSidebarWith.max}
+              minimumWidth={this.state.rootSidebarWith.min}
+              onReset={this.handleRootSidebarWidthReset}
+              onResize={this.handleRootSidebarResize}
+            >
+              {this.renderRepositoryList()}
+            </Resizable>
+          ) : null}
           <div style={{ flex: 1 }}>
             {this.renderToolbar()}
             {this.renderBanner()}
@@ -2944,6 +2952,7 @@ export class App extends React.Component<IAppProps, IAppState> {
     const enableFocusTrap = this.state.currentPopup === null
     return (
       <ToolbarDropdown
+        disabled={this.state.showRootSidebar}
         icon={icon}
         title={title}
         description={__DARWIN__ ? 'Current Repository' : 'Current repository'}

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -953,6 +953,10 @@ export class Dispatcher {
     return this.appStore._setSidebarWidth(width)
   }
 
+  public setRootSidebarWidth(width: number): Promise<void> {
+    return this.appStore._setRootSidebarWidth(width)
+  }
+
   /**
    * Set the update banner's visibility
    */
@@ -992,6 +996,10 @@ export class Dispatcher {
    */
   public resetSidebarWidth(): Promise<void> {
     return this.appStore._resetSidebarWidth()
+  }
+
+  public resetRootSidebarWidth(): Promise<void> {
+    return this.appStore._resetRootSidebarWidth()
   }
 
   /**

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -942,6 +942,10 @@ export class Dispatcher {
     return this.appStore._revertCommit(repository, commit)
   }
 
+  public setShowRootSidebar(show: boolean) {
+    return this.appStore._setShowRootSidebar(show)
+  }
+
   /**
    * Set the width of the repository sidebar to the given
    * value. This affects the changes and history sidebar

--- a/app/styles/_ui.scss
+++ b/app/styles/_ui.scss
@@ -1,4 +1,5 @@
 @import 'ui/app';
+@import 'ui/app-root-column-layout';
 @import 'ui/app-menu';
 @import 'ui/scroll';
 @import 'ui/window/title-bar';

--- a/app/styles/ui/_app-root-column-layout.scss
+++ b/app/styles/ui/_app-root-column-layout.scss
@@ -1,0 +1,15 @@
+@import '../mixins';
+
+#app-root-column-layout {
+  display: flex;
+  flex-direction: row;
+  flex: 1 1 auto;
+  height: 100%;
+  min-height: 0;
+
+  &-sidebar {
+    height: 100%;
+    border-right: 1px solid var(--box-border-color);
+    flex-shrink: 0;
+  }
+}


### PR DESCRIPTION
Add an ability to toggle the repository list as a pinned sidebar

## Description

- Add a root level sidebar, to show the original repository list content (`this.renderRepositoryList()`)
- The root level sidebar is resizable, with a `rootSidebarWidth` in the `app-state` and `app-store`
- Add a menu item to toggle the visibility of the root sidebar 

### Screenshots

Pinned

<img width="1388" alt="image" src="https://github.com/leavez/github-desktop/assets/4454541/68489ee3-fa2c-4d73-9043-e8af44e7b12c">

Hidden

<img width="1380" alt="image" src="https://github.com/leavez/github-desktop/assets/4454541/70c4623d-8bca-45cb-a6cd-d25e80e09eb0">

Menu 

<img width="380" alt="image" src="https://github.com/leavez/github-desktop/assets/4454541/98202982-accb-4a1b-b9d9-3d7b5c1ed56f">


## Release notes

Notes: Add an option to toggle repository list as a pinned sidebar

